### PR TITLE
Fix ID handling in PacienteDAO

### DIFF
--- a/src/main/java/udistrital/pacientedao/dao/PacienteDAO.java
+++ b/src/main/java/udistrital/pacientedao/dao/PacienteDAO.java
@@ -48,7 +48,7 @@ public class PacienteDAO implements GenericDAO {
 
     @Override
     public Object buscarPorId(Object id) throws SQLException {
-        int cedula = (Integer) id;
+        long cedula = (Long) id;
         final String sql = "SELECT * FROM public.paciente WHERE cedula = ?";
 
         try (Connection c = con.getConnection();
@@ -103,7 +103,7 @@ public class PacienteDAO implements GenericDAO {
 
     @Override
     public boolean eliminar(Object id) throws SQLException {
-        int cedula = (Integer) id;
+        long cedula = (Long) id;
         final String sql = "DELETE FROM public.paciente WHERE cedula = ?";
 
         try (Connection c = con.getConnection();


### PR DESCRIPTION
## Summary
- use `long` instead of `int` when handling patient IDs in `PacienteDAO`

## Testing
- `javac @sources.txt`

------
https://chatgpt.com/codex/tasks/task_e_685190d26a0c8330954db23ef62b8625