### PR TITLE
Agregar clase Telefonof y DAO para tabla telefonof

### DIFF
--- a/src/main/java/udistrital/pacientedao/dao/TelefonofDAO.java
+++ b/src/main/java/udistrital/pacientedao/dao/TelefonofDAO.java
@@ -1,0 +1,94 @@
+package udistrital.pacientedao.dao;
+
+import udistrital.pacientedao.db.DBConnection;
+import udistrital.pacientedao.modelo.Telefonof;
+
+import java.sql.Connection;
+import java.sql.PreparedStatement;
+import java.sql.ResultSet;
+import java.sql.SQLException;
+import java.util.ArrayList;
+
+/**
+ * DAO para la entidad Telefonof.
+ */
+public class TelefonofDAO implements GenericDAO {
+
+    private DBConnection con;
+
+    public TelefonofDAO(DBConnection con) {
+        this.con = con;
+    }
+
+    @Override
+    public boolean crear(Object obj) throws SQLException {
+        Telefonof t = (Telefonof) obj;
+        final String sql = "INSERT INTO public.telefonof (telefonof, idfarmacia) VALUES (?,?)";
+        try (Connection c = con.getConn();
+             PreparedStatement ps = c.prepareStatement(sql)) {
+            ps.setLong(1, t.getTelefonof());
+            ps.setInt(2, t.getIdFarmacia());
+            ps.executeUpdate();
+        }
+        return true;
+    }
+
+    @Override
+    public Object buscarPorId(Object id) throws SQLException {
+        long telefono = (Long) id;
+        final String sql = "SELECT * FROM public.telefonof WHERE telefonof = ?";
+        try (Connection c = con.getConn();
+             PreparedStatement ps = c.prepareStatement(sql)) {
+            ps.setLong(1, telefono);
+            try (ResultSet rs = ps.executeQuery()) {
+                return rs.next() ? mapear(rs) : null;
+            }
+        }
+    }
+
+    @Override
+    public ArrayList listarTodos() throws SQLException {
+        final String sql = "SELECT * FROM public.telefonof ORDER BY telefonof";
+        try (Connection c = con.getConn();
+             PreparedStatement ps = c.prepareStatement(sql);
+             ResultSet rs = ps.executeQuery()) {
+            ArrayList<Telefonof> lista = new ArrayList<>();
+            while (rs.next()) {
+                lista.add(mapear(rs));
+            }
+            return lista;
+        }
+    }
+
+    @Override
+    public boolean actualizar(Object obj) throws SQLException {
+        Telefonof t = (Telefonof) obj;
+        final String sql = "UPDATE public.telefonof SET idfarmacia = ? WHERE telefonof = ?";
+        try (Connection c = con.getConn();
+             PreparedStatement ps = c.prepareStatement(sql)) {
+            ps.setInt(1, t.getIdFarmacia());
+            ps.setLong(2, t.getTelefonof());
+            ps.executeUpdate();
+        }
+        return true;
+    }
+
+    @Override
+    public boolean eliminar(Object id) throws SQLException {
+        long telefono = (Long) id;
+        final String sql = "DELETE FROM public.telefonof WHERE telefonof = ?";
+        try (Connection c = con.getConn();
+             PreparedStatement ps = c.prepareStatement(sql)) {
+            ps.setLong(1, telefono);
+            ps.executeUpdate();
+        }
+        return true;
+    }
+
+    private Telefonof mapear(ResultSet rs) throws SQLException {
+        return new Telefonof(
+                rs.getLong("telefonof"),
+                rs.getInt("idfarmacia")
+        );
+    }
+}

--- a/src/main/java/udistrital/pacientedao/modelo/Telefonof.java
+++ b/src/main/java/udistrital/pacientedao/modelo/Telefonof.java
@@ -1,0 +1,38 @@
+package udistrital.pacientedao.modelo;
+
+/**
+ * Representa la tabla telefonof.
+ */
+public class Telefonof {
+    private Long telefonof;    // numeric(12,0)
+    private Integer idFarmacia; // numeric(3,0)
+
+    public Telefonof(Long telefonof, Integer idFarmacia) {
+        this.telefonof = telefonof;
+        this.idFarmacia = idFarmacia;
+    }
+
+    public Long getTelefonof() {
+        return telefonof;
+    }
+
+    public void setTelefonof(Long telefonof) {
+        this.telefonof = telefonof;
+    }
+
+    public Integer getIdFarmacia() {
+        return idFarmacia;
+    }
+
+    public void setIdFarmacia(Integer idFarmacia) {
+        this.idFarmacia = idFarmacia;
+    }
+
+    @Override
+    public String toString() {
+        return "Telefonof{" +
+                "telefonof=" + telefonof +
+                ", idFarmacia=" + idFarmacia +
+                '}';
+    }
+}


### PR DESCRIPTION
### Motivation
- Integrar la tabla `telefonof` en el proyecto para permitir operaciones CRUD desde Java contra `public.telefonof`.
- Mapear los tipos SQL `numeric(12,0)` a `Long` y `numeric(3,0)` a `Integer`, y mantener la relación con la tabla `farmacia` mediante el campo `idFarmacia`.

### Description
- Se agregó `src/main/java/udistrital/pacientedao/modelo/Telefonof.java` con los campos `telefonof` (Long), `idFarmacia` (Integer), constructor, getters/setters y `toString`.
- Se agregó `src/main/java/udistrital/pacientedao/dao/TelefonofDAO.java` que implementa `GenericDAO` y proporciona `crear`, `buscarPorId`, `listarTodos`, `actualizar` y `eliminar` con sentencias SQL sobre `public.telefonof`.
- El método `mapear(ResultSet)` construye instancias de `Telefonof` desde filas de resultados y el DAO usa `telefonof` como identificador en `buscarPorId` y `eliminar` en coherencia con la restricción `UNIQUE (telefonof)`.
- El DAO utiliza `DBConnection` para obtener conexiones y `PreparedStatement` para parametrizar las consultas.

### Testing
- Se ejecutó la compilación del proyecto con `mvn -q -DskipTests compile` y la compilación finalizó correctamente.
- No se ejecutaron tests unitarios automatizados en esta rama.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a036e963e048330ba87cfa6ab67e123)